### PR TITLE
Handle sparse combo arrays 

### DIFF
--- a/graphics.lua
+++ b/graphics.lua
@@ -906,7 +906,8 @@ function Stack.render(self)
         comboData[i] = 0
       end
     end
-    for i = #comboData, 0, -1 do
+    local maxCombo = maxComboReached(analytic.data)
+    for i = maxCombo, 0, -1 do
       if comboData[i] and comboData[i] == 0 then
         comboData[i] = nil
       else


### PR DESCRIPTION
If you have never had a analytics file you might have sparse indexes into the combo dictionary. This can also happen from the engine.

Thus we need to handle sparse dictionarys always. Instead of filling it in with zeros, which could get holes later, just fix every call site to handle the sparse dictionary.

Also fixed some analyzer errors and reduced the size of some pcalls