### PR TITLE
Get battle room out of match

### DIFF
--- a/AttackEngine.lua
+++ b/AttackEngine.lua
@@ -33,7 +33,9 @@ AttackEngine =
     CharacterLoader.load(self.character)
     CharacterLoader.wait()
     self.telegraph = Telegraph(sender)
-    self:setGarbageTarget(garbageTarget)
+    if garbageTarget then
+      self:setGarbageTarget(garbageTarget)
+    end
     self.shouldPlayAttackSfx = shouldPlayAttackSfx
   end
 )

--- a/BattleRoom.lua
+++ b/BattleRoom.lua
@@ -93,7 +93,7 @@ function BattleRoom.createLocalFromGameMode(gameMode)
 end
 
 function BattleRoom.setWinCounts(self, winCounts)
-  for i = 1, winCounts do
+  for i = 1, #winCounts do
     self.players[i].wins = winCounts[i]
   end
 end

--- a/GameModes.lua
+++ b/GameModes.lua
@@ -1,94 +1,155 @@
 require("localization")
+local tableUtils = require("tableUtils")
 
 local GameModes = {}
 
 local Styles = { CHOOSE = 0, CLASSIC = 1, MODERN = 2}
 local FileSelection = { NONE = 0, TRAINING = 1, PUZZLE = 2}
 local StackInteraction = { NONE = 0, VERSUS = 1, SELF = 2, ATTACK_ENGINE = 3, HEALTH_ENGINE = 4}
-local WinConditions = { GAME_OVER = 1, SCORE = 2, TIME = 3 }
+local WinConditions = { GAME_OVER = 1, SCORE = 2, TIME = 3, NO_MATCHABLE_PANELS = 4, NO_MATCHABLE_GARBAGE = 5 }
+local GameOverConditions = { NEGATIVE_HEALTH = 1, TIME_OUT = 2, SCORE_REACHED = 3, NO_MOVES_LEFT = 4, CHAIN_DROPPED = 5 }
 
 local OnePlayerVsSelf = {
-  playerCount = 1,
   style = Styles.MODERN,
   selectFile = FileSelection.NONE,
-  stackInteraction = StackInteraction.SELF,
   scene = "VsSelfGame",
   richPresenceLabel = loc("mm_1_vs"),
+
+  -- already known match properties
+  playerCount = 1,
+  stackInteraction = StackInteraction.SELF,
   winConditions = { },
+  gameOverConditions = { GameOverConditions.NEGATIVE_HEALTH },
   doCountdown = true,
+
+  -- flags to know what other properties match needs
+  needsPuzzle = false,
+  needsAttackEngine = false,
+  needsHealth = false,
 }
 
 local OnePlayerTimeAttack = {
-  playerCount = 1,
   style = Styles.CHOOSE,
   selectFile = FileSelection.NONE,
-  stackInteraction = StackInteraction.NONE,
   scene = "TimeAttackGame",
   richPresenceLabel = loc("mm_1_time"),
-  winConditions = { }, -- for 2p vs Time Attack: { WinConditions.SCORE }
+
+  -- already known match properties
+  playerCount = 1,
+  stackInteraction = StackInteraction.NONE,
+  winConditions = { },
+  gameOverConditions = { GameOverConditions.NEGATIVE_HEALTH, GameOverConditions.TIME_OUT },
   doCountdown = true,
   timeLimit = TIME_ATTACK_TIME,
+
+  -- flags to know what other properties match needs
+  needsPuzzle = false,
+  needsAttackEngine = false,
+  needsHealth = false,
 }
 
 local OnePlayerEndless = {
-  playerCount = 1,
   style = Styles.CHOOSE,
   selectFile = FileSelection.NONE,
-  stackInteraction = StackInteraction.NONE,
   scene = "EndlessGame",
   richPresenceLabel = loc("mm_1_endless"),
-  winConditions = { }, -- for 2p vs endless: { WinConditions.SCORE, WinConditions.TIME }
+
+  -- already known match properties
+  playerCount = 1,
+  stackInteraction = StackInteraction.NONE,
+  winConditions = { },
+  gameOverConditions = { GameOverConditions.NEGATIVE_HEALTH },
   doCountdown = true,
+
+  -- flags to know what other properties match needs
+  needsPuzzle = false,
+  needsAttackEngine = false,
+  needsHealth = false,
 }
 
 local OnePlayerTraining = {
-  playerCount = 1,
   style = Styles.MODERN,
   selectFile = FileSelection.TRAINING,
-  stackInteraction = StackInteraction.ATTACK_ENGINE,
   scene = "GameBase",
   richPresenceLabel = loc("mm_1_training"),
-  winConditions = { }, -- for 2p vs training: { WinConditions.TIME } 
+
+  -- already known match properties
+  playerCount = 1,
+  stackInteraction = StackInteraction.ATTACK_ENGINE,
+  winConditions = { },
+  gameOverConditions = { GameOverConditions.NEGATIVE_HEALTH },
   doCountdown = true,
+
+  -- flags to know what other properties match needs
+  needsPuzzle = false,
+  needsAttackEngine = true,
+  needsHealth = false,
 }
 
 local OnePlayerPuzzle = {
-  playerCount = 1,
+  -- flags for battleRoom to evaluate and in some cases offer UI for
   style = Styles.MODERN,
   selectFile = FileSelection.PUZZLE,
-  stackInteraction = StackInteraction.NONE,
-  scene = "PuzzleGame",
   richPresenceLabel = loc("mm_1_puzzle"),
+  scene = "PuzzleGame",
+
+  -- already known match properties
+  playerCount = 1,
+  stackInteraction = StackInteraction.NONE,
+  -- these are extended based on the loaded puzzle
   winConditions = { },
+  -- these are extended based on the loaded puzzle
+  gameOverConditions = { GameOverConditions.NEGATIVE_HEALTH },
   doCountdown = false,
+
+  -- flags to know what other properties match needs
+  needsPuzzle = true,
+  needsAttackEngine = false,
+  needsHealth = false,
 }
 
 local OnePlayerChallenge = {
-  playerCount = 1,
   style = Styles.MODERN,
   selectFile = FileSelection.NONE,
-  stackInteraction = StackInteraction.HEALTH_ENGINE,
   scene = "GameBase",
   richPresenceLabel = loc("mm_1_challenge_mode"),
-  winConditions = { WinConditions.GAME_OVER }, -- for 2p vs challenge: { WinConditions.TIME }
+
+  -- already known match properties
+  playerCount = 1,
+  stackInteraction = StackInteraction.HEALTH_ENGINE,
+  winConditions = { WinConditions.GAME_OVER },
+  gameOverConditions = { GameOverConditions.NEGATIVE_HEALTH },
   doCountdown = true,
+
+  -- flags to know what other properties match needs
+  needsPuzzle = false,
+  needsAttackEngine = true,
+  needsHealth = true,
 }
 
 local TwoPlayerVersus = {
-  playerCount = 2,
   style = Styles.MODERN,
-  selectFile = FileSelection.NONE,
-  stackInteraction = StackInteraction.VERSUS,
   scene = "Game2pVs",
   richPresenceLabel = loc("mm_2_vs"),
+
+  -- already known match properties
+  playerCount = 2,
+  stackInteraction = StackInteraction.VERSUS,
   winConditions = { WinConditions.GAME_OVER},
+  gameOverConditions = { GameOverConditions.NEGATIVE_HEALTH },
   doCountdown = true,
+
+  -- flags to know what other properties match needs
+  needsPuzzle = false,
+  needsAttackEngine = false,
+  needsHealth = false,
 }
 
 GameModes.Styles = Styles
 GameModes.FileSelection = FileSelection
 GameModes.StackInteraction = StackInteraction
 GameModes.WinCondition = WinConditions
+GameModes.GameOverCondition = GameOverConditions
 
 GameModes.ONE_PLAYER_VS_SELF = OnePlayerVsSelf
 GameModes.ONE_PLAYER_TIME_ATTACK = OnePlayerTimeAttack

--- a/Player.lua
+++ b/Player.lua
@@ -64,7 +64,7 @@ function Player:createStackFromSettings(match, which)
   args.character = self.settings.characterId
   if self.settings.style == GameModes.Styles.MODERN then
     args.level = self.settings.level
-    if match.battleRoom.mode.stackInteraction == GameModes.StackInteraction.NONE then
+    if match.stackInteraction == GameModes.StackInteraction.NONE then
       args.allowAdjacentColors = true
     else
       args.allowAdjacentColors = args.level < 8
@@ -82,6 +82,8 @@ function Player:createStackFromSettings(match, which)
   args.inputMethod = self.settings.inputMethod
 
   self.stack = Stack(args)
+  -- so the stack can draw player information
+  self.stack.player = self
 
   return self.stack
 end

--- a/engine.lua
+++ b/engine.lua
@@ -1285,8 +1285,8 @@ function Stack.shouldDropGarbage(self)
       -- attackengine garbage higher than 1 (aka chain garbage) is treated as combo garbage
       -- that is to circumvent the garbage queue not allowing to send multiple chains simultaneously
       -- and because of that hack, we need to do another hack here and allow n-height combo garbage
-      -- but only if trainingmodesettings have been set on the GAME global
-      return next_garbage_block_height > 1 and GAME.battleRoom.trainingModeSettings ~= nil
+      -- but only if attackEngineSettings have been set on the match
+      return next_garbage_block_height > 1 and self.match.attackEngineSettings ~= nil
     end
   end
 end

--- a/engine.lua
+++ b/engine.lua
@@ -59,7 +59,7 @@ Stack =
       s.panels_dir = config.panels
     end
 
-    if s.match.battleRoom.mode == GameModes.ONE_PLAYER_PUZZLE then
+    if s.match.puzzle then
       s.drawsAnalytics = false
     else
       s.do_first_row = true
@@ -189,7 +189,7 @@ Stack =
     s.cur_col = 3 -- the column the left half of the cursor's on
     s.queuedSwapColumn = 0 -- the left column of the two columns to swap or 0 if no swap queued
     s.queuedSwapRow = 0 -- the row of the queued swap or 0 if no swap queued
-    s.top_cur_row = s.height + (s.match.battleRoom.mode == GameModes.ONE_PLAYER_PUZZLE and 0 or -1)
+    s.top_cur_row = s.height + (s.match.puzzle and 0 or -1)
 
     s.poppedPanelIndex = s.poppedPanelIndex or 1
     s.panels_cleared = s.panels_cleared or 0
@@ -1194,7 +1194,7 @@ function Stack.updateDangerBounce(self)
     end
   end
   if self.danger then
-    if self.panels_in_top_row and self.speed ~= 0 and self.match.battleRoom.mode ~= GameModes.ONE_PLAYER_PUZZLE then
+    if self.panels_in_top_row and self.speed ~= 0 and not self.match.puzzle then
       -- Player has topped out, panels hold the "flattened" frame
       self.danger_timer = 15
     elseif self.stop_time == 0 then
@@ -1334,7 +1334,7 @@ function Stack.simulate(self)
     -- Phase 0 //////////////////////////////////////////////////////////////
     -- Stack automatic rising
     if self.speed ~= 0 and not self.manual_raise and self.stop_time == 0 and not self.rise_lock then
-      if self.match.battleRoom.mode == GameModes.ONE_PLAYER_PUZZLE then
+      if self.match.puzzle then
         -- only reduce health after the first swap to give the player a chance to strategize
         if self.puzzle.puzzleType == "clear" and self.puzzle.remaining_moves - self.puzzle.moves < 0 and self.shake_time < 1 then
           self.health = self.health - 1
@@ -1347,7 +1347,7 @@ function Stack.simulate(self)
             self:set_game_over()
           end
         else
-          if self.match.battleRoom.mode ~= GameModes.ONE_PLAYER_PUZZLE then
+          if not self.match.puzzle then
             self.rise_timer = self.rise_timer - 1
             if self.rise_timer <= 0 then -- try to rise
               self.displacement = self.displacement - 1
@@ -1363,7 +1363,7 @@ function Stack.simulate(self)
       end
     end
 
-    if not self.panels_in_top_row and self.match.battleRoom.mode ~= GameModes.ONE_PLAYER_PUZZLE and not self:has_falling_garbage() then
+    if not self.panels_in_top_row and not self.match.puzzle and not self:has_falling_garbage() then
       self.health = self.levelData.maxHealth
     end
 
@@ -1446,7 +1446,7 @@ function Stack.simulate(self)
     end
 
     -- MANUAL STACK RAISING
-    if self.manual_raise and self.match.battleRoom.mode ~= GameModes.ONE_PLAYER_PUZZLE then
+    if self.manual_raise and not self.match.puzzle then
       if not self.rise_lock then
         if self.panels_in_top_row then
           self:set_game_over()
@@ -1920,7 +1920,7 @@ end
 -- Returns true if the stack is simulated past the end of the match.
 function Stack.game_ended(self)
 
-  if self.match.battleRoom.mode == GameModes.ONE_PLAYER_PUZZLE then
+  if self.match.puzzle then
     if self:puzzle_done() or self:puzzle_failed() then
       return true
     else
@@ -1990,7 +1990,7 @@ function Stack.gameResult(self)
     end
   end
 
-  if self.match.battleRoom.mode == GameModes.ONE_PLAYER_PUZZLE then
+  if self.match.puzzle then
     if self:puzzle_done() then
       return 1
     elseif self:puzzle_failed() then

--- a/engine/GarbageQueue.lua
+++ b/engine/GarbageQueue.lua
@@ -22,6 +22,8 @@ GarbageQueue = class(function(s)
       for k,v in pairs(garbage) do
         local width, height, metal, from_chain, finalized = unpack(v)
         if width and height then
+          -- this being a global reference really sucks here, now that attackEngineSettings live on match
+          -- have to take care of that when getting to it
           if metal and (GAME.battleRoom.trainingModeSettings == nil or GAME.battleRoom.trainingModeSettings.attackSettings == nil or not GAME.battleRoom.trainingModeSettings.attackSettings.mergeComboMetalQueue) then
             self.metal:push(v)
           elseif from_chain or (height > 1 and not GAME.battleRoom.trainingModeSettings) then

--- a/engine/telegraph.lua
+++ b/engine/telegraph.lua
@@ -144,6 +144,8 @@ end
 function Telegraph.add_combo_garbage(self, garbage, timeAttackInteracts)
   logger.debug("Telegraph.add_combo_garbage "..(garbage.width or "nil").." "..(garbage.isMetal and "true" or "false"))
   local garbageToSend = {}
+  -- this being a global reference really sucks here, now that attackEngineSettings live on match
+  -- have to take care of that when getting to it
   if garbage.isMetal and (GAME.battleRoom.trainingModeSettings == nil or GAME.battleRoom.trainingModeSettings.attackSettings == nil or not GAME.battleRoom.trainingModeSettings.attackSettings.mergeComboMetalQueue) then
     garbageToSend[#garbageToSend+1] = {garbage.width, garbage.height, true, false, timeAttackInteracts = timeAttackInteracts}
     self.stoppers.metal = timeAttackInteracts + GARBAGE_TRANSIT_TIME + GARBAGE_TELEGRAPH_TIME
@@ -156,6 +158,8 @@ function Telegraph.add_combo_garbage(self, garbage, timeAttackInteracts)
 end
 
 function Telegraph:chainingEnded(frameEnded)
+  -- this being a global reference really sucks here, now that attackEngineSettings live on match
+  -- have to take care of that when getting to it
   if not GAME.battleRoom.trainingModeSettings then
     assert(frameEnded == self.sender.clock, "expected sender clock to equal attack")
   end

--- a/graphics.lua
+++ b/graphics.lua
@@ -722,7 +722,7 @@ function Stack.render(self)
 
   local function drawMoveCount()
     -- draw outside of stack's frame canvas
-    if self.match.battleRoom.mode == GameModes.ONE_PLAYER_PUZZLE then
+    if self.match.puzzle then
       self:drawLabel(self.theme.images.IMG_moves, self.theme.moveLabel_Pos, self.theme.moveLabel_Scale, false, true)
       local moveNumber = math.abs(self.puzzle.remaining_moves)
       if self.puzzle.puzzleType == "moves" then
@@ -910,7 +910,7 @@ function Stack.render(self)
   drawMoveCount()
   -- Draw the "extra" game info
   if config.show_ingame_infos then
-    if self.match.battleRoom.mode ~= GameModes.ONE_PLAYER_PUZZLE then
+    if not self.match.puzzle then
       drawScore()
       drawSpeed()
     end
@@ -918,7 +918,7 @@ function Stack.render(self)
   end
 
   -- Draw VS HUD
-  if self.match.battleRoom then
+  if self.player then
     self:drawPlayerName()
     self:drawWinCount()
     self:drawRating()
@@ -940,7 +940,7 @@ function Stack:drawWinCount()
   end
 
   self:drawLabel(self.theme.images.IMG_wins, self.theme.winLabel_Pos, self.theme.winLabel_Scale, true)
-  self:drawNumber(self.match.battleRoom.players[self.player_number]:getWinCountForDisplay(), self.wins_quads, self.theme.win_Pos, self.theme.win_Scale, true)
+  self:drawNumber(self.player:getWinCountForDisplay(), self.wins_quads, self.theme.win_Pos, self.theme.win_Scale, true)
 end
 
 function Stack:drawRating()
@@ -1018,7 +1018,7 @@ function Stack:drawMultibar()
   local shake_time = self.shake_time
 
   -- before the first move, display the stop time from the puzzle, not the stack
-  if self.match.battleRoom.mode == GameModes.ONE_PLAYER_PUZZLE and self.puzzle.puzzleType == "clear" and self.puzzle.moves == self.puzzle.remaining_moves then
+  if self.match.puzzle and self.puzzle.puzzleType == "clear" and self.puzzle.moves == self.puzzle.remaining_moves then
     stop_time = self.puzzle.stop_time
     shake_time = self.puzzle.shake_time
   end

--- a/replay.lua
+++ b/replay.lua
@@ -1,14 +1,9 @@
-local utf8 = require("utf8Additions")
 local logger = require("logger")
 local GameModes = require("GameModes")
 local ReplayV1 = require("replayV1")
 local ReplayV2 = require("replayV2")
-local Player = require("Player")
 
 local REPLAY_VERSION = 2
-local tableUtils = require("tableUtils")
-local levelPresets = require("LevelPresets")
-local consts = require("consts")
 
 -- A replay is a particular recording of a play of the game. Temporarily this is just helper methods.
 Replay =
@@ -27,9 +22,12 @@ function Replay.createNewReplay(match)
   result.gameMode = {
     stackInteraction = match.stackInteraction,
     winConditions = match.winConditions or {},
+    gameOverConditions = match.gameOverConditions,
     timeLimit = match.timeLimit,
     doCountdown = match.doCountdown or true
   }
+  result.puzzle = match.puzzle
+  result.attackEngineSettings = match.attackEngineSettings
 
   result.players = {}
   for i = 1, #match.players do

--- a/replayV1.lua
+++ b/replayV1.lua
@@ -33,7 +33,8 @@ function ReplayV1.loadFromFile(legacyReplay)
   r.gameMode = {
     stackInteraction = gameMode.stackInteraction,
     winConditions = gameMode.winConditions,
-    doCountdown = v1r.do_countdown
+    gameOverConditions = gameMode.gameOverConditions,
+    doCountdown = v1r.do_countdown,
   }
 
   if mode == "time" then


### PR DESCRIPTION
This rethinks GameModes a bit by introducing `GameOverConditions` on top of the already existing `WinConditions`.
With this, win conditions are supposed to decide the outcome on the match level between two or more players.
GameOverConditions on the other hand are supposed to decide game over on the stack level.
This is supposed to be a step towards making puzzle behaviour a regularly configurable case rather than plastering `if self.match.puzzle` everywhere to take diverging branches while in puzzle mode. Instead it's going to be `if tableUtils.contains(self.winConditions, WinConditions.NO_MATCHABLE_PANELS)` and similar stuff.
Still a lot missing in that direction though.

More importantly this branch removes all™ references to `battleRoom` from `Stack` and `Match`, further solidfying its status as a high level element while Stack and especially Match made some steps towards being more self-contained classes.