### PR TITLE
Reduce match presence on stack

### DIFF
--- a/ChallengeMode.lua
+++ b/ChallengeMode.lua
@@ -100,6 +100,7 @@ end
 function ChallengeMode:recordStageResult(gameResult, gameLength)
   local lastStageIndex = self.currentStageIndex
 
+  -- TODO: gameResult was phased out, needs different if conditions / parameter
   if gameResult > 0 then
     self.nextStageIndex = self.currentStageIndex + 1
   elseif gameResult < 0 then

--- a/engine.lua
+++ b/engine.lua
@@ -1675,15 +1675,15 @@ function Stack.simulate(self)
       end
       if SFX_Countdown_Play == 1 then
         if self.which == 1 then
-          self.theme.sounds.countdown:stop()
-          self.theme.sounds.countdown:play()
+          -- self.theme.sounds.countdown:stop()
+          -- self.theme.sounds.countdown:play()
         end
         SFX_Countdown_Play = 0
       end
       if SFX_Go_Play == 1 then
         if self.which == 1 then
-          self.theme.sounds.go:stop()
-          self.theme.sounds.go:play()
+          -- self.theme.sounds.go:stop()
+          -- self.theme.sounds.go:play()
         end
         SFX_Go_Play = 0
       end

--- a/engine.lua
+++ b/engine.lua
@@ -1209,43 +1209,37 @@ end
 -- Changed this to play danger when something in top 3 rows
 -- and to play normal music when nothing in top 3 or 4 rows
 function Stack.shouldPlayDangerMusic(self)
-  if self.match.timeLimit then
-    if self.game_stopwatch > TIME_ATTACK_TIME * 60 - 900 --[[15 seconds assuming 60 FPS]] then
-      return true
+  if not self.danger_music then
+    -- currently playing normal music
+    for row = self.height - 2, self.height do
+      local panelRow = self.panels[row]
+      for column = 1, self.width do
+        if panelRow[column].color ~= 0 and panelRow[column].state ~= "falling" or panelRow[column]:dangerous() then
+          if self.shake_time > 0 then
+            return false
+          else
+            return true
+          end
+        end
+      end
     end
   else
-    if not self.danger_music then
-      -- currently playing normal music
-      for row = self.height - 2, self.height do
-        local panelRow = self.panels[row]
+    --currently playing danger
+    local minRowForDangerMusic = self.height - 2
+    if config.danger_music_changeback_delay then
+      minRowForDangerMusic = self.height - 3
+    end
+    for row = minRowForDangerMusic, self.height do
+      local panelRow = self.panels[row]
+      if panelRow ~= nil and type(panelRow) == "table" then
         for column = 1, self.width do
-          if panelRow[column].color ~= 0 and panelRow[column].state ~= "falling" or panelRow[column]:dangerous() then
-            if self.shake_time > 0 then
-              return false
-            else
-              return true
-            end
+          if panelRow[column].color ~= 0 then
+            return true
           end
         end
-      end
-    else
-      --currently playing danger
-      local minRowForDangerMusic = self.height - 2
-      if config.danger_music_changeback_delay then
-        minRowForDangerMusic = self.height - 3
-      end
-      for row = minRowForDangerMusic, self.height do
-        local panelRow = self.panels[row]
-        if panelRow ~= nil and type(panelRow) == "table" then
-          for column = 1, self.width do
-            if panelRow[column].color ~= 0 then
-              return true
-            end
-          end
-        elseif self.warningsTriggered["Panels Invalid"] == nil then
-          logger.warn("Panels have invalid data in them, please tell your local developer." .. dump(panels, true))
-          self.warningsTriggered["Panels Invalid"] = true
-        end
+      elseif self.warningsTriggered["Panels Invalid"] == nil then
+        logger.warn("Panels have invalid data in them, please tell your local developer." .. dump(panels, true))
+        self.warningsTriggered["Panels Invalid"] = true
       end
     end
   end
@@ -1744,32 +1738,6 @@ function Stack.behindRollback(self)
 
   return false
 end
-
-function Stack.shouldChangeMusic(self)
-  local result = not self.match.isPaused and not GAME.muteSoundEffects
-
-  if result then
-    if self:game_ended() or self.canvas == nil then
-      result = false
-    end
-
-    -- If we are still catching up from rollback don't play sounds again
-    if self:behindRollback() then
-      result = false
-    end
-
-    if self.play_to_end then
-      result = false
-    end
-
-    if self.opponentStack and self.opponentStack.play_to_end then
-      result = false
-    end
-  end
-
-  return result
-end
-
 
 function Stack:canPlaySfx()
   -- this should be superfluous because there is no code being run that would play sfx

--- a/engine.lua
+++ b/engine.lua
@@ -1005,8 +1005,7 @@ function Stack.controls(self)
   end
 end
 
-function Stack.shouldRun(self, runsSoFar) 
-
+function Stack.shouldRun(self, runsSoFar)
   -- We want to run after game over to show game over effects.
   if self:game_ended() then
     return runsSoFar == 0
@@ -1039,7 +1038,7 @@ function Stack.shouldRun(self, runsSoFar)
       end
     end
   end
-    
+
   -- If we are not local, we want to run faster to catch up.
   if buffer_len >= 15 - runsSoFar then
     -- way behind, run at max speed.
@@ -1928,85 +1927,32 @@ function Stack.game_ended(self)
     else
       return false
     end
+  else
+    return self.game_over
   end
 
-  local gameEndedClockTime = self.match:gameEndedClockTime()
+  -- local gameEndedClockTime = self.match:gameEndedClockTime()
 
-  if self.match.stackInteraction == GameModes.StackInteractions.HEALTH_ENGINE then
-    if self.match.simulatedOpponent and self.match.simulatedOpponent:isDefeated() then
-      return true
-    end
-  elseif self.match.timeLimit then
-    if self.game_stopwatch then
-      if self.game_stopwatch > TIME_ATTACK_TIME * 60 then
-        return true
-      end
-    end
-  end
+  -- if self.match.stackInteraction == GameModes.StackInteractions.HEALTH_ENGINE then
+  --   if self.match.simulatedOpponent and self.match.simulatedOpponent:isDefeated() then
+  --     return true
+  --   end
+  -- elseif self.match.timeLimit then
+  --   if self.game_stopwatch then
+  --     if self.game_stopwatch > TIME_ATTACK_TIME * 60 then
+  --       return true
+  --     end
+  --   end
+  -- end
 
   -- The universal game end condition for everything but puzzles, one of the stacks went game over
   -- Note we use "greater" and not "greater than or equal" because our stack may be currently processing this clock frame.
   -- At the end of the clock frame it will be incremented and we know we have process the game over clock frame.
-  if gameEndedClockTime > 0 and self.clock > gameEndedClockTime then
-    return true
-  end
+  -- if gameEndedClockTime > 0 and self.clock > gameEndedClockTime then
+  --   return true
+  -- end
 
-  return false
-end
-
--- Returns 1 if this player won, 0 for draw, and -1 for loss, nil if no result yet
-function Stack.gameResult(self)
-  if self:game_ended() == false then
-    return nil
-  end
-
-  local gameEndedClockTime = self.match:gameEndedClockTime()
-
-  if self.match.stackInteraction == GameModes.StackInteractions.HEALTH_ENGINE then
-    if self.match.simulatedOpponent and self.match.simulatedOpponent:isDefeated() then
-      return 1
-    end
-  end
-
-  if self.match.stackInteraction == GameModes.StackInteractions.SELF then
-    -- can't win against yourself :-(
-    return -1
-  end
-
-  if self.match.stackInteraction == GameModes.StackInteractions.VERSUS then
-    if self.opponentStack:game_ended() then
-      if self.game_over_clock == gameEndedClockTime and self.opponentStack.game_over_clock == gameEndedClockTime then
-        return 0
-      elseif self.game_over_clock == gameEndedClockTime then
-        return -1
-      elseif self.opponentStack.game_over_clock == gameEndedClockTime then
-        return 1
-      end
-    end
-  end
-
-  if self.match.timeLimit and self.game_stopwatch then
-    if self.game_stopwatch > self.match.timeLimit * 60 then
-      -- we didn't die within the time limit so that's a win I guess?
-      return 1
-    end
-  end
-
-  if self.puzzle then
-    if self:puzzle_done() then
-      return 1
-    elseif self:puzzle_failed() then
-      return -1
-    end
-  end
-
-  if #self.match.players == 1 then
-    if gameEndedClockTime > 0 and self.clock > gameEndedClockTime then
-      return -1
-    end
-  end
-
-  return nil
+  -- return false
 end
 
 -- Sets the current stack as "lost"

--- a/engine.lua
+++ b/engine.lua
@@ -59,7 +59,7 @@ Stack =
       s.panels_dir = config.panels
     end
 
-    if s.match.puzzle then
+    if s.puzzle then
       s.drawsAnalytics = false
     else
       s.do_first_row = true
@@ -189,7 +189,7 @@ Stack =
     s.cur_col = 3 -- the column the left half of the cursor's on
     s.queuedSwapColumn = 0 -- the left column of the two columns to swap or 0 if no swap queued
     s.queuedSwapRow = 0 -- the row of the queued swap or 0 if no swap queued
-    s.top_cur_row = s.height + (s.match.puzzle and 0 or -1)
+    s.top_cur_row = s.height + (s.puzzle and 0 or -1)
 
     s.poppedPanelIndex = s.poppedPanelIndex or 1
     s.panels_cleared = s.panels_cleared or 0
@@ -1194,7 +1194,7 @@ function Stack.updateDangerBounce(self)
     end
   end
   if self.danger then
-    if self.panels_in_top_row and self.speed ~= 0 and not self.match.puzzle then
+    if self.panels_in_top_row and self.speed ~= 0 and not self.puzzle then
       -- Player has topped out, panels hold the "flattened" frame
       self.danger_timer = 15
     elseif self.stop_time == 0 then
@@ -1334,7 +1334,7 @@ function Stack.simulate(self)
     -- Phase 0 //////////////////////////////////////////////////////////////
     -- Stack automatic rising
     if self.speed ~= 0 and not self.manual_raise and self.stop_time == 0 and not self.rise_lock then
-      if self.match.puzzle then
+      if self.puzzle then
         -- only reduce health after the first swap to give the player a chance to strategize
         if self.puzzle.puzzleType == "clear" and self.puzzle.remaining_moves - self.puzzle.moves < 0 and self.shake_time < 1 then
           self.health = self.health - 1
@@ -1347,7 +1347,7 @@ function Stack.simulate(self)
             self:set_game_over()
           end
         else
-          if not self.match.puzzle then
+          if not self.puzzle then
             self.rise_timer = self.rise_timer - 1
             if self.rise_timer <= 0 then -- try to rise
               self.displacement = self.displacement - 1
@@ -1363,7 +1363,7 @@ function Stack.simulate(self)
       end
     end
 
-    if not self.panels_in_top_row and not self.match.puzzle and not self:has_falling_garbage() then
+    if not self.panels_in_top_row and not self.puzzle and not self:has_falling_garbage() then
       self.health = self.levelData.maxHealth
     end
 
@@ -1446,7 +1446,7 @@ function Stack.simulate(self)
     end
 
     -- MANUAL STACK RAISING
-    if self.manual_raise and not self.match.puzzle then
+    if self.manual_raise and not self.puzzle then
       if not self.rise_lock then
         if self.panels_in_top_row then
           self:set_game_over()
@@ -1922,7 +1922,7 @@ end
 -- Returns true if the stack is simulated past the end of the match.
 function Stack.game_ended(self)
 
-  if self.match.puzzle then
+  if self.puzzle then
     if self:puzzle_done() or self:puzzle_failed() then
       return true
     else
@@ -1992,7 +1992,7 @@ function Stack.gameResult(self)
     end
   end
 
-  if self.match.puzzle then
+  if self.puzzle then
     if self:puzzle_done() then
       return 1
     elseif self:puzzle_failed() then

--- a/engine.lua
+++ b/engine.lua
@@ -1643,16 +1643,6 @@ function Stack.simulate(self)
       end
     end
 
-    -- In time attack, play countdown sound every second when there's 15 seconds left
-    if  self.match.timeLimit and
-        self.game_stopwatch and
-        self.game_stopwatch >= TIME_ATTACK_TIME * 60 - 900 and
-        self.game_stopwatch % 60 == 0 and 
-        self.game_stopwatch ~= TIME_ATTACK_TIME * 60 and           -- don't play on the last frame
-        self:shouldChangeSoundEffects() then
-      SFX_Countdown_Play = 1
-    end
-
     -- Update Sound FX
     if self:shouldChangeSoundEffects() then
       if SFX_Swap_Play == 1 then
@@ -1672,20 +1662,6 @@ function Stack.simulate(self)
         self.theme.sounds.land:stop()
         self.theme.sounds.land:play()
         self.sfx_land = false
-      end
-      if SFX_Countdown_Play == 1 then
-        if self.which == 1 then
-          -- self.theme.sounds.countdown:stop()
-          -- self.theme.sounds.countdown:play()
-        end
-        SFX_Countdown_Play = 0
-      end
-      if SFX_Go_Play == 1 then
-        if self.which == 1 then
-          -- self.theme.sounds.go:stop()
-          -- self.theme.sounds.go:play()
-        end
-        SFX_Go_Play = 0
       end
       if self.combo_chain_play then
         -- stop ongoing landing sound
@@ -1813,14 +1789,6 @@ function Stack:runCountDownIfNeeded()
         self.countdown_timer = nil
         self.countdown_clock = nil
         self.game_stopwatch_running = true
-        if self.which == 1 and self:shouldChangeSoundEffects() then
-          SFX_Go_Play = 1
-        end
-      elseif self.countdown_timer and self.countdown_timer % 60 == 0 and self.which == 1 then
-        --play beep for timer dropping to next second in 3-2-1 countdown
-        if self.which == 1 and self:shouldChangeSoundEffects() then
-          SFX_Countdown_Play = 1
-        end
       end
       if self.countdown_timer then
         self.countdown_timer = self.countdown_timer - 1

--- a/engine/checkMatches.lua
+++ b/engine/checkMatches.lua
@@ -314,7 +314,7 @@ end
 function Stack:matchGarbagePanels(garbagePanels, garbageMatchTime, isChain, onScreenCount)
   garbagePanels = sortByPopOrder(garbagePanels, true)
 
-  if self:shouldChangeSoundEffects() then
+  if self:canPlaySfx() then
     SFX_garbage_match_play = true
   end
   
@@ -477,7 +477,7 @@ function Stack:awardStopTime(isChain, comboSize)
 end
 
 function Stack:queueAttackSoundEffect(isChainLink, chainSize, comboSize, metalCount)
-  if self:shouldChangeSoundEffects() then
+  if self:canPlaySfx() then
     self.combo_chain_play = Stack.attackSoundInfoForMatch(isChainLink, chainSize, comboSize, metalCount)
   end
 end

--- a/graphics.lua
+++ b/graphics.lua
@@ -722,7 +722,7 @@ function Stack.render(self)
 
   local function drawMoveCount()
     -- draw outside of stack's frame canvas
-    if self.match.puzzle then
+    if self.puzzle then
       self:drawLabel(self.theme.images.IMG_moves, self.theme.moveLabel_Pos, self.theme.moveLabel_Scale, false, true)
       local moveNumber = math.abs(self.puzzle.remaining_moves)
       if self.puzzle.puzzleType == "moves" then
@@ -910,7 +910,7 @@ function Stack.render(self)
   drawMoveCount()
   -- Draw the "extra" game info
   if config.show_ingame_infos then
-    if not self.match.puzzle then
+    if not self.puzzle then
       drawScore()
       drawSpeed()
     end
@@ -1018,7 +1018,7 @@ function Stack:drawMultibar()
   local shake_time = self.shake_time
 
   -- before the first move, display the stop time from the puzzle, not the stack
-  if self.match.puzzle and self.puzzle.puzzleType == "clear" and self.puzzle.moves == self.puzzle.remaining_moves then
+  if self.puzzle and self.puzzle.puzzleType == "clear" and self.puzzle.moves == self.puzzle.remaining_moves then
     stop_time = self.puzzle.stop_time
     shake_time = self.puzzle.shake_time
   end

--- a/match.lua
+++ b/match.lua
@@ -302,6 +302,7 @@ function Match:run()
   end
 
   self:playCountdownSfx()
+  self:playTimeLimitDepletingSfx()
   local endTime = love.timer.getTime()
   local timeDifference = endTime - startTime
   self.timeSpentRunning = self.timeSpentRunning + timeDifference
@@ -318,7 +319,7 @@ function Match:updateClock()
 end
 
 function Match:playCountdownSfx()
-  if self.doCountdown then
+  if not GAME.muteSoundEffects and self.doCountdown then
     if self.clock < 200 then
       local tickIndex = math.floor(self.clock / 60)
       if not self.ticksPlayed[tickIndex] then
@@ -336,7 +337,17 @@ function Match:playCountdownSfx()
 end
 
 function Match:playTimeLimitDepletingSfx()
-
+  if not GAME.muteSoundEffects and self.timeLimit then
+    -- have to account for countdown
+    if self.clock >= self.panicTickStartTime then
+      local tickIndex = math.ceil((self.clock - self.panicTickStartTime) / 60)
+      if self.panicTicksPlayed[tickIndex] == false then
+        themes[config.theme].sounds.countdown:stop()
+        themes[config.theme].sounds.countdown:play()
+        self.panicTicksPlayed[tickIndex] = true
+      end
+    end
+  end
 end
 
 function Match:getInfo()
@@ -447,6 +458,11 @@ function Match:start()
     self.panicTicksPlayed = {}
     for i = 1, 15 do
       self.panicTicksPlayed[i] = false
+    end
+
+    self.panicTickStartTime = (self.timeLimit - 15) * 60
+    if self.doCountdown then
+      self.panicTickStartTime = self.panicTickStartTime + 180
     end
   end
 

--- a/match.lua
+++ b/match.lua
@@ -372,6 +372,11 @@ function Match:updateMusic()
     -- but only if we actually have danger music
     local wantsDangerMusic = self.musicSource.musics["danger_music"] and tableUtils.trueForAny(self.players, function(p) return p.stack.danger_music end)
 
+    if self.timeLimit and not wantsDangerMusic then
+      -- danger music is played during panic time even if none is in danger
+      wantsDangerMusic = self.musicSource.musics["danger_music"] and self.clock >= self.panicTickStartTime
+    end
+
     if self.musicSource.music_style == "dynamic" then
       local fadeLength = 60
       if not self.fade_music_clock then

--- a/match_graphics.lua
+++ b/match_graphics.lua
@@ -193,11 +193,9 @@ function Match:render()
     drawY = drawY + padding
     gprintf("Seed " .. self.seed, drawX, drawY)
 
-    local gameEndedClockTime = self:gameEndedClockTime()
-
-    if gameEndedClockTime > 0 then
+    if self.gameOverClock > 0 then
       drawY = drawY + padding
-      gprintf("gameEndedClockTime " .. gameEndedClockTime, drawX, drawY)
+      gprintf("gameOverClock " .. self.gameOverClock, drawX, drawY)
     end
 
     -- drawY = drawY + padding

--- a/replay.lua
+++ b/replay.lua
@@ -95,7 +95,7 @@ function Replay.loadFromPath(path)
 end
 
 function Replay.addAnalyticsDataToReplay(match, replay)
-  replay.duration = match:gameEndedClockTime()
+  replay.duration = match.gameOverClock
 
   for i = 1, #match.players do
     local stack = match.players[i].stack

--- a/scenes/CharacterSelect.lua
+++ b/scenes/CharacterSelect.lua
@@ -335,7 +335,7 @@ function CharacterSelect:update()
   for i = 1, #self.ui.cursors do
     self.ui.cursors[i]:receiveInputs(self.ui.cursors[i].player.inputConfiguration)
   end
-  if GAME.battleRoom.spectating then
+  if GAME.battleRoom and GAME.battleRoom.spectating then
     if input.isDown["MenuEsc"] then
       GAME.battleRoom:shutdown()
       sceneManager:switchToScene(sceneManager:createScene("Lobby"))

--- a/scenes/GameBase.lua
+++ b/scenes/GameBase.lua
@@ -42,10 +42,6 @@ local GameBase = class(
 
 -- begin abstract functions
 
--- Game mode specific post processing on the final game result (saving scores, replays, etc.)
--- Called during unload()
-function GameBase:processGameResults(gameResult) end
-
 -- Game mode specific game state setup
 -- Called during load()
 function GameBase:customLoad(sceneParams) end

--- a/scenes/OptionsMenu.lua
+++ b/scenes/OptionsMenu.lua
@@ -101,7 +101,7 @@ local function createConfigSlider(configField, min, max, onValueChangeFn)
   return Slider({
     min = min,
     max = max,
-    value = config[configField] or 20,
+    value = config[configField] or 0,
     tickLength = math.ceil(100 / max),
     onValueChange = function(slider)
       config[configField] = slider.value
@@ -502,7 +502,7 @@ end
 function OptionsMenu:loadDebugMenu()
   local debugMenuOptions = {
     {Label({width = MENU_WIDTH, text = "op_debug"}), createToggleButtonGroup("debug_mode")},
-    {Label({width = MENU_WIDTH, text = "VS Frames Behind", translate = false}), createConfigSlider("debug_vsFramesBehind", -200, 200)},
+    {Label({width = MENU_WIDTH, text = "VS Frames Behind", translate = false}), createConfigSlider("debug_vsFramesBehind", 0, 200)},
     {Label({width = MENU_WIDTH, text = "Show Debug Servers", translate = false}), createToggleButtonGroup("debugShowServers")},
     {Label({width = MENU_WIDTH, text = "Show Design Helper", translate = false}), createToggleButtonGroup("debugShowDesignHelper")}, {
       TextButton({

--- a/sound.lua
+++ b/sound.lua
@@ -116,3 +116,12 @@ function stopIfPlaying(audioSource)
     audioSource:stop()
   end
 end
+
+SoundController = {}
+
+function SoundController.playSfx(sfx)
+  if not GAME.muteSoundEffects then
+    stopIfPlaying(sfx)
+    sfx:play()
+  end
+end

--- a/tests/StackReplayTests.lua
+++ b/tests/StackReplayTests.lua
@@ -169,7 +169,9 @@ local function basicVsTest()
   assert(match.P2.level == 10)
   assert(tableUtils.length(match.P2.chains) == 4)
   assert(tableUtils.length(match.P2.combos) == 4)
-  assert(match.P1:gameResult() == -1)
+  local winners = match:getWinners()
+  assert(#winners == 1)
+  assert(winners[1].playerNumber == 2)
 end
 
 logger.info("running basicVsTest")
@@ -191,7 +193,9 @@ local function basicVsTest2()
   assert(match.P2.level == 10)
   assert(tableUtils.length(match.P2.chains) == 5)
   assert(tableUtils.length(match.P2.combos) == 8)
-  assert(match.P1:gameResult() == -1)
+  local winners = match:getWinners()
+  assert(#winners == 1)
+  assert(winners[1].playerNumber == 2)
 end
 
 logger.info("running basicVsTest2")
@@ -211,7 +215,8 @@ local function noInputsInVsIsDrawTest()
   assert(match.P2.level == 10)
   assert(tableUtils.length(match.P2.chains) == 0)
   assert(tableUtils.length(match.P2.combos) == 0)
-  assert(match.P1:gameResult() == 0)
+  local winners = match:getWinners()
+  assert(#winners == 2)
 end
 
 logger.info("running noInputsInVsIsDrawTest")
@@ -251,7 +256,9 @@ local function catchAndSyncTest()
   assert(match.P2.level == 8)
   assert(tableUtils.length(match.P2.chains) == 2)
   assert(tableUtils.length(match.P2.combos) == 2)
-  assert(match.P1:gameResult() == 1)
+  local winners = match:getWinners()
+  assert(#winners == 1)
+  assert(winners[1].playerNumber == 1)
 end
 
 logger.info("running catchAndSyncTest")


### PR DESCRIPTION
This aims to move some match wide functionalities that currently live on stack to match itself and reduce references to match in `Stack` in the process.
Not aiming to be exhaustive but sensible:
- for puzzle mode checks, stacks check `self.puzzle` instead of `self.match.puzzle`
- `Stack.gameResult` got retired in favor of `Match:getWinners()` and match being in charge of determining game end / results
- `Match:gameEndedClockTime()` got retired in favor of a field that is updated during the `hasEnded` check
- match is now in charge
  - playing countdown
  - playing panic countdown (at the end of time attack)
  - changing music