### PR TITLE
Error handler fallback

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -207,7 +207,7 @@ function love.errorhandler(msg)
     local detailedErrorLogString = Game.detailedErrorLogString(errorData)
     errorData.detailedErrorLogString = detailedErrorLogString
     if GAME_UPDATER_GAME_VERSION then
-      if GAME.tcpClient:isConnected() then
+      if not GAME.tcpClient:isConnected() then
         GAME.tcpClient:connectToServer(consts.SERVER_LOCATION, 59569)
       end
       GAME.tcpClient:sendErrorReport(errorData)


### PR DESCRIPTION
I had some issues with instant crashes so I wrapped the error data collection on `GAME` (including the disconnect from the server) inside a pcall to ensure we always get an error screen.