### PR TITLE
Scene refactor puzzle behaviours

### DIFF
--- a/GameModes.lua
+++ b/GameModes.lua
@@ -7,8 +7,13 @@ local GameModes = {}
 local Styles = { CHOOSE = 0, CLASSIC = 1, MODERN = 2}
 local FileSelection = { NONE = 0, TRAINING = 1, PUZZLE = 2}
 local StackInteractions = { NONE = 0, VERSUS = 1, SELF = 2, ATTACK_ENGINE = 3, HEALTH_ENGINE = 4}
-local WinConditions = { LAST_ALIVE = 1, SCORE = 2, TIME = 3, NO_MATCHABLE_PANELS = 4, NO_MATCHABLE_GARBAGE = 5 }
-local GameOverConditions = { NEGATIVE_HEALTH = 1, TIME_OUT = 2, SCORE_REACHED = 3, NO_MOVES_LEFT = 4, CHAIN_DROPPED = 5 }
+
+-- these are competitive win conditions to determine a winner across multiple stacks
+local MatchWinConditions = { LAST_ALIVE = 1, SCORE = 2, TIME = 3 }
+-- these are game winning objectives on the stack level, the stack stops running without going game over
+local GameWinConditions = { NO_MATCHABLE_PANELS = 1, NO_MATCHABLE_GARBAGE = 2, SCORE_REACHED = 3}
+-- these are game losing objectives on the stack level, the stack goes game over
+local GameOverConditions = { NEGATIVE_HEALTH = 1, TIME_OUT = 2, NO_MOVES_LEFT = 3, CHAIN_DROPPED = 4 }
 
 local OnePlayerVsSelf = {
   style = Styles.MODERN,
@@ -124,7 +129,7 @@ local OnePlayerChallenge = {
   -- already known match properties
   playerCount = 1,
   stackInteraction = StackInteractions.VERSUS,
-  winConditions = { WinConditions.LAST_ALIVE },
+  winConditions = { MatchWinConditions.LAST_ALIVE },
   gameOverConditions = { GameOverConditions.NEGATIVE_HEALTH },
   doCountdown = true,
 
@@ -143,7 +148,7 @@ local TwoPlayerVersus = {
   -- already known match properties
   playerCount = 2,
   stackInteraction = StackInteractions.VERSUS,
-  winConditions = { WinConditions.LAST_ALIVE},
+  winConditions = { MatchWinConditions.LAST_ALIVE},
   gameOverConditions = { GameOverConditions.NEGATIVE_HEALTH },
   doCountdown = true,
 
@@ -156,7 +161,8 @@ local TwoPlayerVersus = {
 GameModes.Styles = Styles
 GameModes.FileSelection = FileSelection
 GameModes.StackInteractions = StackInteractions
-GameModes.WinConditions = WinConditions
+GameModes.WinConditions = MatchWinConditions
+GameModes.GameWinConditions = GameWinConditions
 GameModes.GameOverConditions = GameOverConditions
 
 local privateGameModes = {}

--- a/Puzzle.lua
+++ b/Puzzle.lua
@@ -22,10 +22,21 @@ function Puzzle.getLegalCharacters()
   return { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "[", "]", "{", "}", "=" }
 end
 
-function Puzzle.fillMissingPanelsInPuzzleString(puzzleString, width, height)
+function Puzzle:fillMissingPanelsInPuzzleString(width, height)
+  local puzzleString = self.stack
   local boardSizeInPanels = width * height
-  while string.len(puzzleString) < boardSizeInPanels do
-    puzzleString = "0" .. puzzleString
+  if self.puzzleType == "clear" then
+    -- first fill up the currently started row
+    local fillUpLength = (puzzleString:len() % width)
+    if fillUpLength > 0 then
+      puzzleString = string.rep("0", width - fillUpLength) .. puzzleString
+    end
+    -- then fill up with single line garbage to ensure topout
+    while string.len(puzzleString) < boardSizeInPanels do
+      puzzleString = "[" .. string.rep("=", width - 2) .. "]" .. puzzleString
+    end
+  else
+    puzzleString = string.rep("0", boardSizeInPanels - string.len(puzzleString)) .. puzzleString
   end
 
   return puzzleString

--- a/Puzzle.lua
+++ b/Puzzle.lua
@@ -58,10 +58,10 @@ function Puzzle.randomizeColorsInPuzzleString(puzzleString)
   return puzzleString
 end
 
-function Puzzle.horizontallyFlipPuzzleString(puzzleString)
+function Puzzle:horizontallyFlipPuzzleString()
   local rowWidth = 6
   local height = 12
-  puzzleString = Puzzle.fillMissingPanelsInPuzzleString(puzzleString, rowWidth, height)
+  puzzleString = self:fillMissingPanelsInPuzzleString(rowWidth, height)
   local result = ""
   local unreverseMap = {}
   unreverseMap["{"] = "}"

--- a/PuzzleTests.lua
+++ b/PuzzleTests.lua
@@ -102,9 +102,9 @@ PuzzleTests.validationGarbageCoherence4()
 PuzzleTests.validationValid()
 
 function PuzzleTests.testFilledPuzzleString()
-  local puzzleString = "123"
-  local filledString = Puzzle.fillMissingPanelsInPuzzleString(puzzleString, 6, 12)
-  assert(filledString ~= puzzleString)
+  local puzzle = Puzzle("moves", false, 5, "123")
+  local filledString = puzzle:fillMissingPanelsInPuzzleString(6, 12)
+  assert(filledString ~= puzzle.stack)
   assert(filledString:len() == 72)
   assert(filledString == "000000000000000000000000000000000000000000000000000000000000000000000123")
 end
@@ -137,7 +137,8 @@ PuzzleTests.testRandomizeColorsSometimesSameColors()
 
 function PuzzleTests.testHorizontallyFlippedPuzzle()
   local puzzleString = "{====}929999[====]040000224999949999"
-  local flippedString = Puzzle.horizontallyFlipPuzzleString(puzzleString)
+  local puzzle = Puzzle("moves", false, 5, puzzleString)
+  local flippedString = puzzle:horizontallyFlipPuzzleString()
   assert(flippedString == "000000000000000000000000000000000000{====}999929[====]000040999422999949")
 end
 
@@ -145,7 +146,8 @@ PuzzleTests.testHorizontallyFlippedPuzzle()
 
 function PuzzleTests.testHorizontallyFlippedSmallPuzzle()
   local puzzleString = "123"
-  local flippedString = Puzzle.horizontallyFlipPuzzleString(puzzleString)
+  local puzzle = Puzzle("moves", false, 5, puzzleString)
+  local flippedString = puzzle:horizontallyFlipPuzzleString()
   assert(flippedString == "000000000000000000000000000000000000000000000000000000000000000000321000")
 end
 
@@ -153,7 +155,8 @@ PuzzleTests.testHorizontallyFlippedSmallPuzzle()
 
 function PuzzleTests.testHorizontallyFlippedBigGarbagePuzzle()
   local puzzleString = "[============================][====]632620[====]200042543641322141354544463636"
-  local flippedString = Puzzle.horizontallyFlipPuzzleString(puzzleString)
+  local puzzle = Puzzle("moves", false, 5, puzzleString)
+  local flippedString = puzzle:horizontallyFlipPuzzleString()
   assert(flippedString == "[============================][====]026236[====]240002146345141223445453636364")
 end
 
@@ -161,7 +164,8 @@ PuzzleTests.testHorizontallyFlippedBigGarbagePuzzle()
 
 function PuzzleTests.testHorizontallyFlippedSmallGarbagePuzzle()
   local puzzleString = "[============================]00[==]632620[==]00200042543641322141354544463636"
-  local flippedString = Puzzle.horizontallyFlipPuzzleString(puzzleString)
+  local puzzle = Puzzle("moves", false, 5, puzzleString)
+  local flippedString = puzzle:horizontallyFlipPuzzleString()
   assert(flippedString == "[============================][==]0002623600[==]240002146345141223445453636364")
 end
 

--- a/engine.lua
+++ b/engine.lua
@@ -686,9 +686,9 @@ function Stack.set_puzzle_state(self, puzzle)
     self.gameWinConditions[#self.gameWinConditions + 1] = GameModes.GameWinConditions.NO_MATCHABLE_GARBAGE
   elseif puzzle.puzzleType == "chain" then
     self.gameOverConditions[#self.gameOverConditions + 1] = GameModes.GameOverConditions.CHAIN_DROPPED
-    self.gameWinConditions[#self.gameWinConditions + 1] = GameModes.GameOverConditions.NO_MATCHABLE_PANELS
+    self.gameWinConditions[#self.gameWinConditions + 1] = GameModes.GameWinConditions.NO_MATCHABLE_PANELS
   elseif puzzle.puzzleType == "moves" then
-    self.gameWinConditions[#self.gameWinConditions + 1] = GameModes.GameOverConditions.NO_MATCHABLE_PANELS
+    self.gameWinConditions[#self.gameWinConditions + 1] = GameModes.GameWinConditions.NO_MATCHABLE_PANELS
   end
 
   -- transform any cleared garbage into colorless garbage panels
@@ -1687,7 +1687,7 @@ function Stack:game_ended()
   if self.game_over_clock > 0 then
     return self.clock >= self.game_over_clock
   else
-    if #self.gameOverConditions > 0 then
+    if #self.gameWinConditions > 0 then
       return self:checkGameWin()
     else
       return false

--- a/engine.lua
+++ b/engine.lua
@@ -1270,9 +1270,7 @@ function Stack.simulate(self)
       end
     end
 
-    -- TODO: allow clear puzzles to have more than 12 rows so that downstacking isn't feasible
-    -- then this "not self.puzzle" condition can get removed (it's only there to avoid clear puzzles bricking/resetting health)
-    if not self.panels_in_top_row and not self.puzzle and not self:has_falling_garbage() then
+    if not self.panels_in_top_row and not self:has_falling_garbage() then
       self.health = self.levelData.maxHealth
     end
 

--- a/engine/telegraph.lua
+++ b/engine/telegraph.lua
@@ -232,7 +232,7 @@ function Telegraph.pop_all_ready_garbage(self, time_to_check, just_peeking)
   --remove any combo stoppers that expire this frame,
   for combo_garbage_width, combo_release_frame in pairs(subject.stoppers.combo) do
     if combo_release_frame <= time_to_check then
-      logger.debug("removing a combo stopper at " .. combo_release_frame)
+      logger.trace("removing a combo stopper at " .. combo_release_frame)
       subject.stoppers.combo[combo_garbage_width] = nil
     else 
       n_combo_stoppers = n_combo_stoppers + 1

--- a/logger.lua
+++ b/logger.lua
@@ -9,7 +9,7 @@ local INFO = 2 -- Log something that is useful in most normal conditions
 local WARN = 3 -- Log something that could be a problem
 local ERROR = 4 -- Log something that definitely is a problem
 
-local LOG_LEVEL = INFO
+local LOG_LEVEL = DEBUG
 
 -- See comments above about when you should use each logging level
 function logger.trace(msg)

--- a/scenes/CharacterSelect.lua
+++ b/scenes/CharacterSelect.lua
@@ -253,7 +253,7 @@ end
 function CharacterSelect:createLevelSlider(player, imageWidth)
   local levelSlider = LevelSlider({
     tickLength = imageWidth,
-    value = config.level or 5,
+    value = player.settings.level,
     onValueChange = function(s)
       play_optional_sfx(themes[config.theme].sounds.menu_move)
     end,

--- a/scenes/PuzzleGame.lua
+++ b/scenes/PuzzleGame.lua
@@ -44,7 +44,7 @@ function PuzzleGame:customRun()
 end
 
 function PuzzleGame:customGameOverSetup()
-  if self.match.P1:puzzle_done() then -- writes successful puzzle replay and ends game
+  if self.match.P1.game_over_clock <= 0 then -- writes successful puzzle replay and ends game
     self.text = loc("pl_you_win")
     if self.puzzleIndex == #self.puzzleSet.puzzles then
       self.keepMusic = false
@@ -58,7 +58,7 @@ function PuzzleGame:customGameOverSetup()
       -- The character and stage and music and background should all state the same until you complete the whole puzzle set
       self.nextSceneParams = {puzzleSet = self.puzzleSet, puzzleIndex = self.puzzleIndex + 1, character = self.match.players[1].stack.character, loadStageAndMusic = false, match = match}
     end
-  elseif self.match.players[1].stack:puzzle_failed() then
+  elseif self.match.P1.game_over_clock > 0 then
     SFX_GameOver_Play = 1
     self.text = loc("pl_you_lose")
     self.keepMusic = true

--- a/scenes/PuzzleMenu.lua
+++ b/scenes/PuzzleMenu.lua
@@ -105,9 +105,9 @@ function PuzzleMenu:load(sceneParams)
   )
   
   local menuOptions = {
-    {Label({label = Label({text = "level"}), isVisible = false}), self.levelSlider},
-    {Label({label = Label({text = "randomColors"}), isVisible = false}), self.randomColorsButtons},
-    {Label({label = Label({text = "randomHorizontalFlipped"}), isVisible = false}), self.randomlyFlipPuzzleButtons}
+    {Label({text = "level", isVisible = false}), self.levelSlider},
+    {Label({text = "randomColors", isVisible = false}), self.randomColorsButtons},
+    {Label({text = "randomHorizontalFlipped", isVisible = false}), self.randomlyFlipPuzzleButtons}
   }
 
   for puzzleSetName, puzzleSet in pairsSortedByKeys(GAME.puzzleSets) do

--- a/scenes/PuzzleMenu.lua
+++ b/scenes/PuzzleMenu.lua
@@ -103,7 +103,7 @@ function PuzzleMenu:load(sceneParams)
       onChange = function() play_optional_sfx(themes[config.theme].sounds.menu_move) end
     }
   )
-  
+
   local menuOptions = {
     {Label({text = "level", isVisible = false}), self.levelSlider},
     {Label({text = "randomColors", isVisible = false}), self.randomColorsButtons},

--- a/tableUtils.lua
+++ b/tableUtils.lua
@@ -70,7 +70,7 @@ function tableUtils.trueForAll(tab, condition)
 end 
  
 -- appends all entries of tab to the end of list 
-function tableUtils.appendToList(list, tab) 
+function tableUtils.appendToList(list, tab)
   for i = 1, #tab do
     list[#list+1] = tab[i]
   end
@@ -96,12 +96,12 @@ end
 -- appends an element to a table only if it does not contain the element yet 
 -- 
 -- use this when you want to pretend that your table is a hashset 
-function tableUtils.appendIfNotExists(tab, element) 
-  if not tableUtils.contains(tab, element) then 
-    table.insert(tab, #tab + 1, element) 
-  end 
-end 
- 
+function tableUtils.appendIfNotExists(tab, element)
+  if not tableUtils.contains(tab, element) then
+    table.insert(tab, element)
+  end
+end
+
 -- Randomly grabs a value from the table 
 function tableUtils.getRandomElement(tab) 
   if #tab > 0 then


### PR DESCRIPTION
Implements game win conditions as a way for a stack to return true game_ended() without going game over
Implemented the ability to raise manually and passive raise as behaviour flags that can be toggled rather than being specific to puzzle mode
Implemented clear puzzles having stack high combo storm queued so people cannot get away with downstacking if a puzzle is designed to not represent a top out in the initial state (and thus bricking)
Implemented clear puzzles autofilling with single row garbage if not explicitly designated to have empty space above